### PR TITLE
When building the Docker image for Cypress, don't use hosts_lando file

### DIFF
--- a/.github/make_dockerfile.sh
+++ b/.github/make_dockerfile.sh
@@ -30,7 +30,8 @@ lando_section_to_bash() {
   chmod +x "$script"
 
   for i in $(seq 0 $((length - 1))); do
-    yq eval ".services.web.$1[$i]" ../.lando.yml >>"$script"
+    yq eval ".services.web.$1[$i]" ../.lando.yml | \
+      sed 's/hosts_lando/hosts_myinstance/' >>"$script"
   done
   echo "$2" ".github/$script" >>../Dockerfile
 }


### PR DESCRIPTION
This commit is needed because of da515abad1a65bee0d31d9574b1bd844db49a545: The lando build steps are also used for building the Docker image containing the LAMP stack.